### PR TITLE
Fix: Use correct check in auto-merge workflow

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ "{{" }} github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' {{ "}}" }}
+    if: ${{ "{{" }} github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' {{ "}}" }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
We want to check the author of the PR, not of the last commit.

Fixes #23.