### PR TITLE
Fix handling of bot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
-# Ensure that all PRs must be approved by at least one of the below
+# Automatically tag the following users to review PRs
 * @alexdewar @dalonsoa @cc-a @AdrianDAlessandro
+
+# Exclude the following files as they are often updated by bots
+.pre-commit-config.yaml
+{{\ cookiecutter.project_slug\ }}/*requirements.txt

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot and Pre-commit auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write # Needed if in a private repository
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow to auto-merge PRs from bots (#33) and updates the `CODEOWNERS` file so that (hopefully!) we won't all be tagged for these bot PRs (#36).

Closes #33. Closes #36.