### PR TITLE
pre-commit: Add codespell hook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   # publish:
   #   runs-on: ubuntu-latest
   #   needs: test
-  #   # The following steps to build a Docker image and publish to the GitHub container registry on release. Alternatively, can replace with other publising steps (ie. publishing to PyPI, deploying documentation etc.)
+  #   # The following steps to build a Docker image and publish to the GitHub container registry on release. Alternatively, can replace with other publishing steps (ie. publishing to PyPI, deploying documentation etc.)
   #   steps:
   #     - name: Login to GitHub Container Registry
   #       uses: docker/login-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
     rev: v0.41.0
     hooks:
       - id: markdownlint-fix
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [-L, .codespell_ignore.txt]


### PR DESCRIPTION
Add `codespell` `pre-commit` hook. I've found it useful on a few projects so I think it's probably worth rolling out more widely. It generally doesn't produce too many false positives (it errs on the side of false negatives) and you can always add extra words to `.codespell_ignore.txt` if it does.

Closes #30.