### PR TITLE
Add codespell to template's pre-commit config

### DIFF
--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     rev: v0.40.0
     hooks:
       - id: markdownlint-fix
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [-L, .codespell_ignore.txt]


### PR DESCRIPTION
As @AdrianDAlessandro has pointed out, we want this hook for the template too, so that it will be included in new projects.