### PR TITLE
Allow users to opt into/out of different CI runners

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,8 @@
     "use_bsd3_licence": false,
     "add_precommit_workflows": true,
     "automerge_bot_prs": false,
+    "use_windows_ci_runner": false,
+    "use_macos_ci_runner": false,
     "__prompts__": {
         "project_name": "Enter a human-readable name for the project",
         "project_slug": "Enter a name for the Python package",
@@ -17,6 +19,8 @@
         "packaging": "Select the Python packaging tool you wish to use",
         "use_bsd3_licence": "Whether to use Imperial's default open-source licence (BSD 3-clause)",
         "add_precommit_workflows": "Add Github Actions to run pre-commit hooks (only needed for private repositories)",
+        "use_windows_ci_runner": "Add a GitHub Actions runner for Windows (needed if your software targets Windows)",
+        "use_macos_ci_runner": "Add a GitHub Actions runner for macOS (needed if your software targets macOS - ARM)",
         "automerge_bot_prs": "Whether to automatically merge PRs from bots including dependabot"
     }
 }

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os:
+          - ubuntu-latest
+{%- if cookiecutter.use_windows_ci_runner %}
+          - windows-latest
+{%- endif %}
+{%- if cookiecutter.use_macos_ci_runner %}
+          - macos-latest{% endif %}
         python-version: ["3.12"]
 
     steps:


### PR DESCRIPTION
# Description

This PR adds two new options to the `cookiecutter` template, allowing the user to opt into/out of having Windows and macOS runners (specifically `windows-latest` and `macos-latest`). The default is to not have them. The `ubuntu-latest` runner is always included, though maybe we should make this an option too...? Dunno.

The hope is that some new projects will opt not to include these configurations and so will reduce the cost and energy usage of their CI jobs.

Closes #24.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
