### PR TITLE
Fix formatting in auto-merge.yml

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write  # Needed if in a private repository
+  pull-requests: write # Needed if in a private repository
 
 jobs:
   auto-merge:


### PR DESCRIPTION
The current version of auto-merge.yml fails the prettier pre-commit check once you've initialised a repository. This brings it in line.