### PR TITLE
Replace prettier hook with separate formatters for YAML and JSON

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,7 @@
 name: Check links in Markdown files
 on:
   schedule:
-    - cron: "0 0 * * 1" # midnight every Monday
+    - cron: 0 0 * * 1   # midnight every Monday
   push:
     branches: [main]
   pull_request:
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
+          use-quiet-mode: yes
+          use-verbose-mode: yes

--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.12"]
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.12"]
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,18 @@ repos:
       - id: check-merge-conflict
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: pretty-format-json
+        args: [--autofix, --indent, '4', --no-sort]
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.14.0
+    hooks:
+      - id: pretty-format-yaml
+        args: [--autofix, --indent, '2', --offset, '2']
+        exclude: '{{ cookiecutter.project_slug }}/.+'
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.29.0"
+    rev: 0.29.0
     hooks:
       - id: check-github-workflows
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        # Prettier supports many other file formats (e.g., JavaScript, HTML; see
-        # https://prettier.io for list). Add other types here.
-        types_or: [yaml, json]
-        exclude: "{{ cookiecutter.project_slug }}/.+"
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,10 @@
     "project_description": "[Description for project.]",
     "author": "Jane Doe",
     "author_email": "jane_doe@imperial.ac.uk",
-    "packaging": ["poetry", "pip-tools"],
+    "packaging": [
+        "poetry",
+        "pip-tools"
+    ],
     "use_bsd3_licence": false,
     "add_precommit_workflows": true,
     "automerge_bot_prs": false,

--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -5,11 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/{{ cookiecutter.project_slug }}/.github/workflows/check-links.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/check-links.yml
@@ -1,7 +1,7 @@
 name: Check links in Markdown files
 on:
   schedule:
-    - cron: "0 0 * * 1" # midnight every Monday
+    - cron: 0 0 * * 1   # midnight every Monday
   push:
     branches: [main]
   pull_request:
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
+          use-quiet-mode: yes
+          use-verbose-mode: yes

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.12"]
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/pre-commit_autoupdate.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/pre-commit_autoupdate.yml
@@ -2,7 +2,7 @@ name: Pre-commit auto-update
 
 on:
   schedule:
-    - cron: "0 0 * * 1" # midnight every Monday
+    - cron: 0 0 * * 1   # midnight every Monday
 
 jobs:
   auto-update:
@@ -16,5 +16,5 @@ jobs:
           token: ${{ "{{" }} secrets.GITHUB_TOKEN {{ "}}" }}
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
-          commit-message: "chore: update pre-commit hooks"
+          commit-message: 'chore: update pre-commit hooks'
           body: Update versions of pre-commit hooks to latest version.

--- a/{{ cookiecutter.project_slug }}/.markdownlint.yaml
+++ b/{{ cookiecutter.project_slug }}/.markdownlint.yaml
@@ -1,3 +1,2 @@
----
 # Disable checks here
 MD013: false

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -6,25 +6,25 @@ repos:
       - id: debug-statements
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: pretty-format-json
+        args: [--autofix, --indent, '4', --no-sort]
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.14.0
+    hooks:
+      - id: pretty-format-yaml
+        args: [--autofix, --indent, '2', --offset, '2']
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.28.3"
+    rev: 0.28.3
     hooks:
       - id: check-github-workflows
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        # Prettier supports many other file formats (e.g., JavaScript, HTML; see
-        # https://prettier.io for list). Add other types here.
-        types_or: [yaml, json]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.4.4"
+    rev: v0.4.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
+    rev: v1.10.0
     hooks:
       - id: mypy
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/{{ cookiecutter.project_slug }}/.vscode/settings.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/settings.json
@@ -3,8 +3,9 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
-    "editor.rulers": [88],
-
+    "editor.rulers": [
+        88
+    ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
I've fiddled with the settings so that the JSON and YAML output looks similar to what we had before. I still think `prettier` did a better job in places, but this is good enough!

Fixes #52.