### PR TITLE
Remove flake8 logger disabling from cookiecutter template

### DIFF
--- a/{{ cookiecutter.project_slug }}/tests/__init__.py
+++ b/{{ cookiecutter.project_slug }}/tests/__init__.py
@@ -1,6 +1,1 @@
 """Unit tests for MyProject."""
-
-from logging import getLogger
-
-# Disable flake8 logger as it can be rather verbose
-getLogger("flake8").propagate = False


### PR DESCRIPTION
# Description

This PR removes the line that disables the flake8 logger from the `tests/__init__.py` file in the cookiecutter template.

Fixes #70 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
