### PR TITLE
`poetry`: Patch dependency versions after template initialisation

### DIFF
--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev-requirements.txt
 
+      - name: Run unit tests
+        run: pytest
+
       - name: Create project from template
         # Choose default options
         run: cookiecutter . --no-input packaging=pip-tools

--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install cookiecutter
-        run: pip install cookiecutter
+      - name: Install dependencies
+        run: pip install -r dev-requirements.txt
 
       - name: Create project from template
         # Choose default options

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           poetry-version: 1.2.2
 
-      - name: Install cookiecutter
-        run: pip install cookiecutter
+      - name: Install dependencies
+        run: pip install -r dev-requirements.txt
 
       - name: Create project from template
         # Choose default options

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev-requirements.txt
 
+      - name: Run unit tests
+        run: pytest
+
       - name: Create project from template
         # Choose default options
         run: cookiecutter . --no-input packaging=poetry

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+# This file contains dependencies for development and CI workflows
+cookiecutter==2.6.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 # This file contains dependencies for development and CI workflows
 cookiecutter==2.6.0
+pytest==8.3.2

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -23,15 +23,11 @@ def main():
     remove_unneeded_files()
 
 
-def read_package_versions() -> dict[str, str]:
+def read_package_versions(*filenames: str) -> dict[str, str]:
     """Read package versions from *requirements.txt."""
     regex = re.compile("^([^# ]+)==(.+)$")
     packages: dict[str, str] = {}
-    for filename in (
-        "doc-requirements.txt",
-        "dev-requirements.txt",
-        "requirements.txt",
-    ):
+    for filename in filenames:
         with open(filename) as f:
             for line in f.readlines():
                 if match := regex.match(line):
@@ -41,19 +37,22 @@ def read_package_versions() -> dict[str, str]:
     return packages
 
 
-def update_poetry_dependencies():
+def update_poetry_dependencies(pyproject_path: str = "pyproject.toml"):
     """Patch the versions of packages in pyproject.toml."""
-    packages = read_package_versions()
+    packages = read_package_versions(
+        "doc-requirements.txt", "dev-requirements.txt", "requirements.txt"
+    )
+
     output = ""
     regex = re.compile('^([^ ]+) = "VERSION"$')
-    with open("pyproject.toml") as f:
+    with open(pyproject_path) as f:
         for line in f.readlines():
             if match := regex.match(line):
                 name = match.group(1)
                 output += f'{name} = "^{packages[name.lower()]}"\n'
             else:
                 output += line
-    with open("pyproject.toml", "w") as f:
+    with open(pyproject_path, "w") as f:
         f.write(output)
 
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -14,11 +14,17 @@ REMOVE_PATHS = (
     "README.*.jinja",
 )
 
-for path in REMOVE_PATHS:
-    path = path.strip()
-    if path:
-        for inode in glob(path):
-            if os.path.isfile(inode):
-                os.unlink(inode)
-            else:
-                rmtree(path)
+
+def main():
+    for path in REMOVE_PATHS:
+        path = path.strip()
+        if path:
+            for inode in glob(path):
+                if os.path.isfile(inode):
+                    os.unlink(inode)
+                else:
+                    rmtree(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_pyproject_patching.py
+++ b/tests/test_pyproject_patching.py
@@ -1,0 +1,80 @@
+from hooks.post_gen_project import read_package_versions, update_poetry_dependencies
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+
+def test_read_package_versions(tmp_path: Path):
+    REQUIREMENTS1 = """
+# This is a comment
+package_a==1.2.3
+package_b==4.5.6
+"""
+    path1 = tmp_path / "requirements1.txt"
+    with path1.open("w") as f:
+        f.write(REQUIREMENTS1)
+
+    # Single file
+    assert read_package_versions(str(path1)) == {
+        "package_a": "1.2.3",
+        "package_b": "4.5.6",
+    }
+
+    REQUIREMENTS2 = """
+package_b==1.2.3
+# Another comment
+package_c==4.5.6
+"""
+    path2 = tmp_path / "requirements2.txt"
+    with path2.open("w") as f:
+        f.write(REQUIREMENTS2)
+
+    # Multiple files
+    assert read_package_versions(str(path1), str(path2)) == {
+        "package_a": "1.2.3",
+        "package_b": "1.2.3",
+        "package_c": "4.5.6",
+    }
+
+    REQUIREMENTS3 = "package_B==1.2.3"
+    path3 = tmp_path / "requirements3.txt"
+    with path3.open("w") as f:
+        f.write(REQUIREMENTS3)
+
+    # Package names should be converted to lowercase
+    assert read_package_versions(str(path1), str(path3)) == {
+        "package_a": "1.2.3",
+        "package_b": "1.2.3",
+    }
+
+
+PYPROJECT = """[tool.poetry]
+name = "my_project"
+authors = [
+    "Jane Doe <jane_doe@imperial.ac.uk>",
+]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+package_a = "{package_a}"
+
+[tool.poetry.group.dev.dependencies]
+package_b = "{package_b}"
+
+[tool.mypy]
+disallow_any_explicit = true
+
+def test_update_poetry_dependencies(tmp_path: Path):
+"""
+
+
+@patch("hooks.post_gen_project.read_package_versions")
+def test_update_poetry_dependencies(read_versions_mock: Mock, tmp_path: Path):
+    pyproject_path = tmp_path / "pyproject.toml"
+    with pyproject_path.open("w") as f:
+        f.write(PYPROJECT.format(package_a="VERSION", package_b="VERSION"))
+
+    read_versions_mock.return_value = {"package_a": "1.2.3", "package_b": "4.5.6"}
+    update_poetry_dependencies(str(pyproject_path))
+    with pyproject_path.open() as f:
+        content = f.read()
+    assert content == PYPROJECT.format(package_a="^1.2.3", package_b="^4.5.6")

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -12,21 +12,21 @@ authors = [
 python = "^3.12"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.2"
-pytest-cov = "^5.0.0"
-pytest-mypy = "^0.10.0"
-pytest-mock = "^3.7.0"
-pre-commit = "^3.0.4"
-ruff = "^0.4.4"
+pytest = "VERSION"
+pytest-cov = "VERSION"
+pytest-mypy = "VERSION"
+pytest-mock = "VERSION"
+pre-commit = "VERSION"
+ruff = "VERSION"
 {% if cookiecutter.mkdocs %}
 [tool.poetry.group.docs.dependencies]
-mkdocs = "^1.6.0"
-mkdocstrings = "^0.25.1"
-mkdocstrings-python = "^1.10.0"
-mkdocs-material = "^9.5.25"
-mkdocs-gen-files = "^0.5.0"
-mkdocs-literate-nav = "^0.6.1"
-mkdocs-section-index = "^0.3.9"
+mkdocs = "VERSION"
+mkdocstrings = "VERSION"
+mkdocstrings-python = "VERSION"
+mkdocs-material = "VERSION"
+mkdocs-gen-files = "VERSION"
+mkdocs-literate-nav = "VERSION"
+mkdocs-section-index = "VERSION"
 {% endif %}
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Unlike `pip-tools`, which pins dependency versions in standard `requirements.txt`-type files, `poetry` pins the versions in `pyproject.toml`. Unfortunately, as our template's `pyproject.toml` contains some jinja statements (e.g. `<% if` blocks) it is not valid TOML and dependabot is unable to parse it and therefore suggest new versions of packages.

As we have the latest versions of dependencies listed in various `*requirements.txt` files for `pip-tools` though, we can just use these files as a source. This PR changes the post-generation hook to patch the `pyproject.toml` file with these versions when the user has selected `poetry` as a packaging tool.

Closes #18.