### PR TITLE
Remove section about publishing workflow

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -2,8 +2,4 @@
 
 {{ cookiecutter.project_description }}
 
-{% include "README.%s.jinja" % cookiecutter.packaging %}
-## Publishing
-
-The GitHub workflow includes an action to publish on release.
-To run this action, uncomment the commented portion of `publish.yml`, and modify the steps for the desired behaviour (publishing a Docker image, publishing to PyPI, deploying documentation etc.)
+{% include "README.%s.jinja" % cookiecutter.packaging -%}


### PR DESCRIPTION
The generated README.md file currently contains a section about the publishing workflow, which we removed. So let's also remove this section.
