### PR TITLE
Remove pytest-mypy

### DIFF
--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r dev-requirements.txt
+          pip install -e .
 
       - name: Run mypy
         working-directory: my_project

--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Install project dependencies
         working-directory: my_project
-        run: pip install .[dev]
+        run: |
+          pip install --upgrade pip
+          pip install -r dev-requirements.txt
 
       - name: Run mypy
         working-directory: my_project

--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -36,6 +36,10 @@ jobs:
         working-directory: my_project
         run: pip install .[dev]
 
+      - name: Run mypy
+        working-directory: my_project
+        run: mypy .
+
       - name: Run tests
         working-directory: my_project
         run: pytest

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -41,6 +41,10 @@ jobs:
         working-directory: my_project
         run: poetry install
 
+      - name: Run mypy
+        working-directory: my_project
+        run: poetry run mypy .
+
       - name: Run tests
         working-directory: my_project
         run: poetry run pytest

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
+      - name: Run mypy
+        run: poetry run mypy .
+
       - name: Run tests
         run: poetry run pytest
 {%- if cookiecutter.mkdocs %}
@@ -50,6 +53,9 @@ jobs:
 {%- elif cookiecutter.packaging == "pip-tools" %}
       - name: Install dependencies
         run: pip install -r dev-requirements.txt
+
+      - name: Run mypy
+        run: mypy .
 
       - name: Run tests
         run: pytest

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
 {%- endif %}
 {%- elif cookiecutter.packaging == "pip-tools" %}
       - name: Install dependencies
-        run: pip install -r dev-requirements.txt
+        run: |
+          pip install --upgrade pip
+          pip install -r dev-requirements.txt
 
       - name: Run mypy
         run: mypy .

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r dev-requirements.txt
+          pip install -e .
 
       - name: Run mypy
         run: mypy .

--- a/{{ cookiecutter.project_slug }}/README.pip-tools.jinja
+++ b/{{ cookiecutter.project_slug }}/README.pip-tools.jinja
@@ -13,13 +13,14 @@ To get started:
    source .venv/bin/activate # with Powershell on Windows: `.venv\Scripts\Activate.ps1`
    ```
 
-1. Install development requirements:
+1. Install development requirements and the package in editable mode:
 
    ```bash
    pip install -r dev-requirements.txt
+   pip install -e .
    ```
 {% if cookiecutter.mkdocs %}
-1. (Optionally) install tools for building documentation:
+1. Install tools for building documentation:
 
    ```bash
    pip install -r doc-requirements.txt

--- a/{{ cookiecutter.project_slug }}/README.pip-tools.jinja
+++ b/{{ cookiecutter.project_slug }}/README.pip-tools.jinja
@@ -20,7 +20,7 @@ To get started:
    pip install -e .
    ```
 {% if cookiecutter.mkdocs %}
-1. Install tools for building documentation:
+1. (Optionally) install tools for building documentation:
 
    ```bash
    pip install -r doc-requirements.txt

--- a/{{ cookiecutter.project_slug }}/dev-requirements.txt
+++ b/{{ cookiecutter.project_slug }}/dev-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --extra=dev --output-file=dev-requirements.txt pyproject.toml
 #
-attrs==24.2.0
-    # via pytest-mypy
 build==1.2.2.post1
     # via pip-tools
 cfgv==3.4.0
@@ -17,17 +15,13 @@ coverage[toml]==7.6.3
 distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
-    # via
-    #   pytest-mypy
-    #   virtualenv
+    # via virtualenv
 identify==2.6.1
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
 mypy==1.11.2
-    # via
-    #   datahub (pyproject.toml)
-    #   pytest-mypy
+    # via my_project (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
@@ -37,33 +31,30 @@ packaging==24.1
     #   build
     #   pytest
 pip-tools==7.4.1
-    # via datahub (pyproject.toml)
+    # via my_project (pyproject.toml)
 platformdirs==4.3.6
     # via virtualenv
 pluggy==1.5.0
     # via pytest
 pre-commit==4.0.0
-    # via datahub (pyproject.toml)
+    # via my_project (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pytest==8.3.3
     # via
-    #   datahub (pyproject.toml)
+    #   my_project (pyproject.toml)
     #   pytest-cov
     #   pytest-mock
-    #   pytest-mypy
 pytest-cov==5.0.0
-    # via datahub (pyproject.toml)
+    # via my_project (pyproject.toml)
 pytest-mock==3.14.0
-    # via datahub (pyproject.toml)
-pytest-mypy==0.10.3
-    # via datahub (pyproject.toml)
+    # via my_project (pyproject.toml)
 pyyaml==6.0.2
     # via pre-commit
 ruff==0.6.8
-    # via datahub (pyproject.toml)
+    # via my_project (pyproject.toml)
 typing-extensions==4.12.2
     # via mypy
 virtualenv==20.26.6

--- a/{{ cookiecutter.project_slug }}/dev-requirements.txt
+++ b/{{ cookiecutter.project_slug }}/dev-requirements.txt
@@ -21,7 +21,7 @@ identify==2.6.1
 iniconfig==2.0.0
     # via pytest
 mypy==1.11.2
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
@@ -31,30 +31,30 @@ packaging==24.1
     #   build
     #   pytest
 pip-tools==7.4.1
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 platformdirs==4.3.6
     # via virtualenv
 pluggy==1.5.0
     # via pytest
 pre-commit==4.0.0
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pytest==8.3.3
     # via
-    #   my_project (pyproject.toml)
+    #   {{ cookiecutter.project_slug }} (pyproject.toml)
     #   pytest-cov
     #   pytest-mock
 pytest-cov==5.0.0
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 pytest-mock==3.14.0
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 pyyaml==6.0.2
     # via pre-commit
 ruff==0.6.8
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 typing-extensions==4.12.2
     # via mypy
 virtualenv==20.26.6

--- a/{{ cookiecutter.project_slug }}/doc-requirements.txt
+++ b/{{ cookiecutter.project_slug }}/doc-requirements.txt
@@ -54,27 +54,27 @@ mkdocs==1.6.1
     #   mkdocs-material
     #   mkdocs-section-index
     #   mkdocstrings
-    #   my_project (pyproject.toml)
+    #   {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocs-autorefs==1.2.0
     # via mkdocstrings
 mkdocs-gen-files==0.5.0
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-literate-nav==0.6.1
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocs-material==9.5.40
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocs-section-index==0.3.9
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocstrings==0.26.1
     # via
     #   mkdocstrings-python
-    #   my_project (pyproject.toml)
+    #   {{ cookiecutter.project_slug }} (pyproject.toml)
 mkdocstrings-python==1.11.1
-    # via my_project (pyproject.toml)
+    # via {{ cookiecutter.project_slug }} (pyproject.toml)
 packaging==24.1
     # via mkdocs
 paginate==0.5.7

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -14,9 +14,9 @@ authors = [
 python = "^3.12"
 
 [tool.poetry.group.dev.dependencies]
+mypy = "VERSION"
 pytest = "VERSION"
 pytest-cov = "VERSION"
-pytest-mypy = "VERSION"
 pytest-mock = "VERSION"
 pre-commit = "VERSION"
 ruff = "VERSION"
@@ -55,7 +55,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-mypy",
     "pytest-mock",
 ]
 {% if cookiecutter.mkdocs %}doc = [
@@ -89,7 +88,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
-addopts = "-v --mypy -p no:warnings --cov={{ cookiecutter.project_slug }} --cov-report=html --doctest-modules --ignore={{ cookiecutter.project_slug }}/__main__.py"
+addopts = "-v -p no:warnings --cov={{ cookiecutter.project_slug }} --cov-report=html --doctest-modules --ignore={{ cookiecutter.project_slug }}/__main__.py"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
# Description

This removes `pytest-mypy` because of the issue with test discovery in the vscode extension. To make up for it, mypy has bee added to CI.

There is a chance the CI tests will fail because of either the `run: pip install .[dev]` making `mypy .` fail, or the `test_version` test causing problems with if we do `run: pip install -r dev-requirements.txt`. So this will need to be resolved either way.

Fixes #135 

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
