### PR TITLE
Fix codespell arg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: [-L, .codespell_ignore.txt]
+        args: [-I, .codespell_ignore.txt]

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: [-L, .codespell_ignore.txt]
+        args: [-I, .codespell_ignore.txt]


### PR DESCRIPTION
It turns out that -L lets you provide a list of words to ignore *on the command line*. What we actually want is to provide a file with a list of words to be ignored. The correct option for this is -I.

The reason we didn't notice is because the file is currently empty, but it will be frustrating for whoever actually tries to add something to it!