### PR TITLE
Fix copyright attributions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Imperial College London
+Copyright (c) 2024, Imperial College London. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Alex Dewar
+Copyright (c) 2024, Imperial College London
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/{{ cookiecutter.project_slug }}/LICENSE
+++ b/{{ cookiecutter.project_slug }}/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Alex Dewar
+Copyright (c) 2024, {{ cookiecutter.author }}
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
@AdrianDAlessandro has pointed out that the copyright for the repo and for anything generated from the template is attributed to me personally. For the repo, it should be attributed to ICL.

Users of the template *may* want to attribute it to ICL too (but they won't want to attribute it to me!). It seemed like unnecessary hassle to add another prompt about this though, so I just changed it to use the author's name, which is probably also fine for most cases.

Fixes #84.