### PR TITLE
Remove reference to sphinx

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@ Fixes # (issue)
 ## Key checklist
 
 - [ ] All tests pass (eg. `python -m pytest`)
-- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
 - [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
 
 ## Further checks

--- a/{{ cookiecutter.project_slug }}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/{{ cookiecutter.project_slug }}/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,9 @@ Fixes # (issue)
 ## Key checklist
 
 - [ ] All tests pass (eg. `python -m pytest`)
+{%- if cookiecutter.mkdocs %}
 - [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
+{%- endif %}
 - [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
 
 ## Further checks


### PR DESCRIPTION
The PR template references sphinx, even though we're not using it for this repo (or, indeed, any doc framework).

I also made the corresponding checklist point for the template conditional on whether or not docs are enabled.

Fixes #78.