### PR TITLE
Fix: Use correct version of Python for `poetry` tests

### DIFF
--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r dev-requirements.txt

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -18,14 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Poetry
+        run: pipx install poetry
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v3.0.0
-        with:
-          poetry-version: 1.2.2
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r dev-requirements.txt


### PR DESCRIPTION
# Description

This PR changes the GitHub workflows from using the `setup-poetry` action to manually installing `poetry` via `pipx` instead. This fixes an issue we're seeing on the Windows runner where the runner's system version of Python is being used by poetry rather than the one we specify (i.e. 3.12).

Interestingly, we had already updated this in the workflows for the template (i.e. the ones which will end up in users' repos) but must have forgotten to do the same for this repo's workflows.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
