### PR TITLE
CI: Swap `markdown-link-check` for Linkspector

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,10 +9,12 @@ on:
 
 jobs:
   check-links:
+    name: Linkspector
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
         with:
-          use-quiet-mode: yes
-          use-verbose-mode: yes
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review

--- a/{{ cookiecutter.project_slug }}/.github/workflows/check-links.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/check-links.yml
@@ -9,10 +9,12 @@ on:
 
 jobs:
   check-links:
+    name: Linkspector
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
         with:
-          use-quiet-mode: yes
-          use-verbose-mode: yes
+          github_token: ${{ "{{" }} secrets.github_token {{ "}}" }}
+          reporter: github-pr-review


### PR DESCRIPTION
This PR replaces the `markdown-link-check` CI workflow with the Linkspector one, as I did for the blog, both for the repo itself and in the template. It has some technical advantages (e.g. it comments on PRs indicating which links are failing) and also doesn't give as many spurious failures for valid links.

Closes #247.