### PR TITLE
Add instructions for enabling auto-merge on your repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ To use this template for your own application:
 
 [Install `cookiecutter`]:
     https://cookiecutter.readthedocs.io/en/stable/README.html#installation
+
+# Extra setup
+
+## Auto-merging bot PRs
+
+This template optionally includes a [GitHub Actions] workflow to automatically merge PRs
+from bots (specifically for [dependabot] and [pre-commit.ci]). However, in order for
+this to work, you will first need to [follow GitHub's instructions] for enabling
+auto-merge on your repository.
+
+[GitHub Actions]: https://github.com/features/actions
+[dependabot]: https://github.com/dependabot
+[pre-commit.ci]: https://pre-commit.ci
+[follow GitHub's instructions]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#enabling-auto-merge


### PR DESCRIPTION
# Description

Even if users choose the option to automatically merge bot PRs, it won't do anything unless they enable auto-merge for their repo. Add instructions for doing this to the readme.

Closes #207.

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
