### PR TITLE
Auto-approve in auto merge workflow

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/auto-merge.yml
@@ -13,7 +13,9 @@ jobs:
     if: ${{ "{{" }} github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' {{ "}}" }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ "{{" }} github.event.pull_request.html_url {{ "}}" }}
           # GitHub provides this variable in the CI env. You don't


### PR DESCRIPTION
# Description

The auto merge workflow doesn't currently automatically approve the PRs, so they still require approvals if there are branch protections.

Close #265

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
