### PR TITLE
`pyproject.toml`: Drop some poetry-specific sections no longer needed in v2

### DIFF
--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -88,7 +88,10 @@ select = [
 pydocstyle.convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D100", "D104"] # Missing docstring in public module, Missing docstring in public package
+"tests/*" = [
+    "D100",  # Missing docstring in public module
+    "D104"   # Missing docstring in public package
+]
 
 {% if cookiecutter.packaging == "pip-tools" -%}
 [build-system]

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -1,14 +1,40 @@
-{%- if cookiecutter.packaging == "poetry" -%}
-[tool.poetry]
+[project]
 name = "{{ cookiecutter.project_slug }}"
-version = "0.1.0"
+dynamic = ["version"]
 description = "{{ cookiecutter.project_description }}"
 authors = [
-    "{{ cookiecutter.author }} <{{ cookiecutter.author_email }}>"
+    { name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}" }
 {%- if cookiecutter.rse_team_as_coauthor %},
-    "Imperial College London RSE Team <ict-rse-team@imperial.ac.uk>"
+    { name = "Imperial College London RSE Team", email = "ict-rse-team@imperial.ac.uk" }
 {%- endif %}
 ]
+{%- if cookiecutter.packaging == "pip-tools" %}
+requires-python = ">=3.13"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "mypy",
+    "pip-tools",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+]
+{% if cookiecutter.mkdocs -%}
+doc = [
+    "mkdocs",
+    "mkdocstrings",
+    "mkdocstrings-python",
+    "mkdocs-material",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
+    "mkdocs-section-index",
+]
+{%- endif %}
+{%- endif %}
+{%- if cookiecutter.packaging == "poetry" %}
 
 [tool.poetry.dependencies]
 python = "^3.13"
@@ -29,52 +55,7 @@ mkdocs-material = "VERSION"
 mkdocs-gen-files = "VERSION"
 mkdocs-literate-nav = "VERSION"
 mkdocs-section-index = "VERSION"
-{% endif %}
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-{%- elif cookiecutter.packaging == "pip-tools" -%}
-[project]
-name = "{{ cookiecutter.project_slug }}"
-dynamic = ["version"]
-description = "{{ cookiecutter.project_description }}"
-authors = [
-    { name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}" }
-{%- if cookiecutter.rse_team_as_coauthor %},
-    { name = "Imperial College London RSE Team", email = "ict-rse-team@imperial.ac.uk" }
-{%- endif %}
-]
-requires-python = ">=3.13"
-dependencies = []
-
-[project.optional-dependencies]
-dev = [
-    "ruff",
-    "mypy",
-    "pip-tools",
-    "pre-commit",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-]
-{% if cookiecutter.mkdocs %}doc = [
-    "mkdocs",
-    "mkdocstrings",
-    "mkdocstrings-python",
-    "mkdocs-material",
-    "mkdocs-gen-files",
-    "mkdocs-literate-nav",
-    "mkdocs-section-index",
-]
-{% endif %}
-[build-system]
-requires = ["setuptools", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages.find]
-exclude = ["htmlcov"] # Exclude the coverage report file from setuptools package finder
-
-[tool.setuptools_scm]
+{%- endif -%}
 {%- endif %}
 
 [tool.mypy]
@@ -108,3 +89,16 @@ pydocstyle.convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D100", "D104"] # Missing docstring in public module, Missing docstring in public package
+
+{% if cookiecutter.packaging == "pip-tools" -%}
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+exclude = ["htmlcov"] # Exclude the coverage report file from setuptools package finder
+{%- elif cookiecutter.packaging == "poetry" -%}
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+{%- endif %}

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -1,6 +1,10 @@
 [project]
 name = "{{ cookiecutter.project_slug }}"
+{%- if cookiecutter.packaging == "poetry" %}
+version = "0.1.0"
+{%- else %}
 dynamic = ["version"]
+{%- endif %}
 description = "{{ cookiecutter.project_description }}"
 authors = [
     { name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}" }


### PR DESCRIPTION
# Description

Poetry v2 adds support for using some generic PEP-compliant sections in the `pyproject.toml`, which means we can simplify our template a bit.

I haven't updated the dependencies sections. While poetry v2 does support using the generic `dependencies` properties, as poetry provides some features not supported by other tools, they've also kept their own forms of these sections. This seems to be the default so I've left it as it is.

Closes #264.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
