### PR TITLE
Remove square brackets from default description

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "My Project",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
-    "project_description": "[Description for project.]",
+    "project_description": "Description for project.",
     "author": "Jane Doe",
     "author_email": "jane_doe@imperial.ac.uk",
     "rse_team_as_coauthor": false,


### PR DESCRIPTION
# Description

The default description has square brackets around it, as if it is a list. I don't believe this is correct/necessary, and it implies that they are needed when answering the cookiecutter steps.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
