### PR TITLE
Add taplo-format to pre-commit to format toml files

### DIFF
--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create project from template
         # Choose default options
-        run: cookiecutter . --no-input packaging=pip-tools
+        run: cookiecutter . --no-input packaging=pip-tools rse_team_as_coauthor=true
 
       - name: Install project dependencies
         working-directory: my_project

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create project from template
         # Choose default options
-        run: cookiecutter . --no-input packaging=poetry
+        run: cookiecutter . --no-input packaging=poetry rse_team_as_coauthor=true
 
       - name: Install project dependencies
         working-directory: my_project

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
     hooks:
       - id: codespell
         args: [-I, .codespell_ignore.txt]
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format # Format TOML files
+      - id: taplo-lint

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
@@ -14,25 +14,25 @@ repos:
       - id: pretty-format-yaml
         args: [--autofix, --indent, '2', --offset, '2']
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.3
+    rev: 0.33.0
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.11.13
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.16.0
     hooks:
       - id: mypy
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.40.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint-fix
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: [-I, .codespell_ignore.txt]

--- a/{{ cookiecutter.project_slug }}/.taplo.toml
+++ b/{{ cookiecutter.project_slug }}/.taplo.toml
@@ -1,0 +1,4 @@
+[formatting]
+compact_inline_tables = true
+column_width = 88
+indent_string = "    "

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -7,9 +7,9 @@ dynamic = ["version"]
 {%- endif %}
 description = "{{ cookiecutter.project_description }}"
 authors = [
-    { name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}" }
+    {name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}"}
 {%- if cookiecutter.rse_team_as_coauthor %},
-    { name = "Imperial College London RSE Team", email = "ict-rse-team@imperial.ac.uk" }
+    {name = "Imperial College London RSE Team", email = "ict-rse-team@imperial.ac.uk"},
 {%- endif %}
 ]
 {%- if cookiecutter.packaging == "pip-tools" %}
@@ -17,15 +17,7 @@ requires-python = ">=3.13"
 dependencies = []
 
 [project.optional-dependencies]
-dev = [
-    "ruff",
-    "mypy",
-    "pip-tools",
-    "pre-commit",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-]
+dev = ["ruff", "mypy", "pip-tools", "pre-commit", "pytest", "pytest-cov", "pytest-mock"]
 {% if cookiecutter.mkdocs -%}
 doc = [
     "mkdocs",
@@ -87,14 +79,14 @@ select = [
     "F",   # Pyflakes
     "I",   # isort
     "UP",  # pyupgrade
-    "RUF"  # ruff
+    "RUF", # ruff
 ]
 pydocstyle.convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "D100",  # Missing docstring in public module
-    "D104"   # Missing docstring in public package
+    "D100", # Missing docstring in public module
+    "D104", # Missing docstring in public package
 ]
 
 {% if cookiecutter.packaging == "pip-tools" -%}


### PR DESCRIPTION
# Description

YAML and JSON files are formatted, but TOML is not. The `pretty-format-toml` in the same repo as `pretty-format-yaml` has some strange behaviour (deleting comments, etc). So I found [this one](https://github.com/ComPWA/taplo-pre-commit) instead.

Seems to work well. See changes in [this commit in pyecn](https://github.com/ImperialCollegeLondon/LiECN/commit/9dfa343f5da7c5bdbca0a5a82b7dd20bad9f9615)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
