### PR TITLE
Use ruff-check in pre-commit

### DIFF
--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.13
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
# Description

Turns out we've been using the legacy version of this and the newest one is called `ruff-check`

https://github.com/astral-sh/ruff-pre-commit


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
