### PR TITLE
Add permissions to write PRs to pre-commit-autoupdate workflow

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/pre-commit_autoupdate.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/pre-commit_autoupdate.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 0 0 * * 1   # midnight every Monday
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

I believe this workflow requires additional permissions to work.

I have made this same change in [this PR](https://github.com/ImperialCollegeLondon/LiECN/pull/463) (private repo). We should wait to merge this until after that workflow has run and we confirm it fixes the issue.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
