### PR TITLE
pre-commit: Also validate dependabot and GitHub Actions files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.2
     hooks:
+      - id: check-dependabot
+      - id: check-github-actions
       - id: check-github-workflows
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.1
     hooks:
+      - id: check-dependabot
+      - id: check-github-actions
       - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.0


### PR DESCRIPTION
# Description

We're already using the `check-jsonschema` pre-commit hook to validate GitHub workflows, but it can also validate other config files, notably for dependabot and GitHub Actions. Update `.pre-commit-config.yaml` to check these too.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
