### PR TITLE
Remove mistakenly added editor.formatOnSave setting

### DIFF
--- a/{{ cookiecutter.project_slug }}/.vscode/settings.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/settings.json
@@ -7,6 +7,5 @@
         88
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "editor.formatOnSave": false
+    "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
# Description

It looks like format on save was mistakenly turned off in this commit https://github.com/ImperialCollegeLondon/python-template/commit/6045935038cbe8f1ef800daed854ac1b8d2fa308

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
