### PR TITLE
Bump minimum Python version to 3.14

### DIFF
--- a/.github/workflows/ci-pip-tools.yml
+++ b/.github/workflows/ci-pip-tools.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-poetry.yml
+++ b/.github/workflows/ci-poetry.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-uv.yml
+++ b/.github/workflows/ci-uv.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/tests/test_pyproject_patching.py
+++ b/tests/test_pyproject_patching.py
@@ -54,7 +54,7 @@ authors = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.14"
 package_a = "{package_a}"
 
 [tool.poetry.group.dev.dependencies]

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 {%- if cookiecutter.use_macos_ci_runner %}
           - macos-latest
 {%- endif %}
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docs.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: poetry
       - name: Install dependencies
         run: poetry install
@@ -45,7 +45,7 @@ jobs:
 {%- elif cookiecutter.packaging == 'pip-tools' %}
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
       - name: Install dependencies
         run: pip install -r doc-requirements.txt
@@ -58,9 +58,9 @@ jobs:
           enable-cache: true
           prune-cache: false
           activate-environment: true
-          python-version: 3.13
+          python-version: 3.14
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.14
       - name: Install dependencies
         run: uv sync --group doc
       - name: Build docs with MkDocs

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -21,7 +21,7 @@ license = {text = "BSD-3-Clause"}
 {%- endif %}
 {%- endif %}
 {%- if cookiecutter.packaging != "poetry" %}
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 
 dependencies = []
 {% if cookiecutter.packaging == "uv" %}
@@ -65,7 +65,7 @@ doc = [
 {%- if cookiecutter.packaging == "poetry" %}
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.14"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "VERSION"
@@ -102,7 +102,7 @@ disallow_untyped_defs = false
 addopts = "-v -p no:warnings --cov={{ cookiecutter.project_slug }} --cov-branch --cov-report=html --cov-report=xml --doctest-modules --ignore={{ cookiecutter.project_slug }}/__main__.py --ignore=docs/"
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
# Description

Python 3.14 has been out since Oct of last year.

There shouldn't be compatibility problems. Arch Linux has migrated to 3.14 for its system Python, so it probably works with most important dependencies, so long as you use recent versions of them.

So let's change this repo to use Python 3.14 so we can use it by default for new projects.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
