### PR TITLE
Group dependabot PRs and reduce update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      python:
+        patterns: ['*']
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,14 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       python:
         patterns: ['*']
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       github-actions:
         patterns: ['*']

--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      python:
+        patterns: ['*']
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns: ['*']


### PR DESCRIPTION
# Description

This PR updates the dependabot configuration for both this repository itself and repositories generated from the template so that dependabot PRs are grouped. I have configured it so that there is one group for Python deps and another for GitHub Actions.

It is also an option to be more granular and only group minor updates, with major updates getting their own PRs as before, but I haven't done this. This would probably be a more conservative choice though (for projects following semver, major updates could include breaking changes) -- maybe we shouldn't rely on users of this repo having a good test suite -- so let me know if you want me to make this change.

I also reduced the update frequency for this repository, but not the template, to monthly. Note that this covers the dependencies for both this repository and the default dependencies for the template. I wonder if monthly updates would be enough for many of our projects too, honestly, but that's probably a discussion for another day.

Closes #138.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
