### PR TITLE
Fix: CODEOWNERS: Exclude users from requirements files in root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Exclude the following files as they are often updated by bots
 .pre-commit-config.yaml
-{{\ cookiecutter.project_slug\ }}/*requirements.txt
+*requirements.txt


### PR DESCRIPTION
# Description

We already exclude codeowners from the `*requirements.txt` file in the template folder, so that a review from @github-actions is sufficient to merge a PR. However, we don't currently exclude the `dev-requirements.txt` file in the root, so although @github-actions approves PRs updating this file, they won't be merged unless one of us also approves it (see example: #535). Fix this.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
