### PR TITLE
Pin mkdocs to v1 series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     groups:
       python:
         patterns: ['*']
+    # NB: mkdocs v2 will include breaking changes.
+    # See: https://github.com/imperialcollegelondon/python-template/discussions/530
+    ignore:
+      - dependency-name: mkdocs
+        update-types: [version-update:semver-major]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,7 +1,7 @@
 import os
+import re
 from glob import glob
 from shutil import rmtree
-import re
 
 REMOVE_PATHS = (
     "{% if not cookiecutter.use_bsd3_license %}LICENSE{% endif %}",
@@ -66,15 +66,16 @@ def update_uv_dependencies(pyproject_path: str = "pyproject.toml"):
     )
 
     output = ""
-    regex = re.compile(r'"([A-Za-z0-9_\-]+)\s*([=<>!~]+)\s*VERSION"')
+    regex = re.compile(r'"([A-Za-z0-9_\-]+)\s*([=<>!~]+)\s*VERSION\s*(.*)"')
     with open(pyproject_path) as f:
         for line in f.readlines():
             if match := regex.match(line.strip()):
                 name = match.group(1)
                 operator = match.group(2)
                 version = packages[name.lower()]
+                trailing = match.group(3)
                 comma = "," if line.strip().endswith(",") else ""
-                output += f'    "{name}{operator}{version}"{comma}\n'
+                output += f'    "{name}{operator}{version}{trailing}"{comma}\n'
             else:
                 output += line
     with open(pyproject_path, "w") as f:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -28,7 +28,7 @@ def main():
 
 def read_package_versions(*filenames: str) -> dict[str, str]:
     """Read package versions from *requirements.txt."""
-    regex = re.compile("^([^# ]+)==(.+)$")
+    regex = re.compile(r"^([^# ]+)==(.+)$")
     packages: dict[str, str] = {}
     for filename in filenames:
         with open(filename) as f:
@@ -47,7 +47,7 @@ def update_poetry_dependencies(pyproject_path: str = "pyproject.toml"):
     )
 
     output = ""
-    regex = re.compile('^([^ ]+) = "VERSION"$')
+    regex = re.compile(r'^([^ ]+) = "VERSION"$')
     with open(pyproject_path) as f:
         for line in f.readlines():
             if match := regex.match(line):

--- a/{{ cookiecutter.project_slug }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_slug }}/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     groups:
       python:
         patterns: ['*']
+    # NB: mkdocs v2 will include breaking changes.
+    # See: https://github.com/imperialcollegelondon/python-template/discussions/530
+    ignore:
+      - dependency-name: mkdocs
+        update-types: [version-update:semver-major]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -36,7 +36,9 @@ dev = [
 ]
 {% if cookiecutter.mkdocs -%}
 doc = [
-    "mkdocs>=VERSION",
+    # NB: mkdocs v2 will include breaking changes.
+    # See: https://github.com/ImperialCollegeLondon/python-template/discussions/530
+    "mkdocs>=VERSION,<2.0.0",
     "mkdocstrings>=VERSION",
     "mkdocstrings-python>=VERSION",
     "mkdocs-material>=VERSION",


### PR DESCRIPTION
# Description

As discussed in #530, `mkdocs` v2 will include breaking changes. As a short-term fix, let's pin the version to <2.

I've done this in a couple of ways:

- Pin the version in `pyproject.toml` when the `uv` packaging option is selected (related: #529)
- Tell dependabot to ignore major version updates for `mkdocs`

I figure we don't need to worry about the `poetry`/`pip-tools` options, partly because the dependabot config change should be enough and partly because we're getting rid of them soon anyway.

Fixes #538.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
