### PR TITLE
Fix README: Add missing `--all-groups` flag to `uv sync`

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.uv.jinja
+++ b/{{ cookiecutter.project_slug }}/README.uv.jinja
@@ -23,7 +23,7 @@ To get started:
 1. Install the package and dependencies and set up the virtual environment:
 
     ```bash
-    uv sync
+    uv sync --all-groups
     ```
 
 1. Activate the virtual environment, or just preface your commands with `uv run` to use


### PR DESCRIPTION
# Description

As the instructions in the README are aimed at developers, they should be running `uv sync --all-groups` so that they also get the dependencies in the `dev` and `docs` groups. Fix this.

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
