### PR TITLE
Add issue forms to this repo and template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,32 @@
+name: Bug report
+description: File a bug report.
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: >
+        A clear and concise description of what the bug is, including error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: How to reproduce
+      description: >
+        Steps to reproduce the behaviour. Attach any relevant input file(s) below.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour (optional)
+      description: >
+        A clear and concise description of what you expected to happen.
+  - type: upload
+    id: upload
+    attributes:
+      label: Upload files (optional)
+      description: >
+        Upload any relevant files here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose a new feature
+labels: [enhancement]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe your proposed feature
+      description: >
+        A clear description of what the new feature should do.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Please describe the problem you are trying to address
+      description: >
+        A clear description of the problem the proposed feature addresses.
+      placeholder: >
+        E.g.: "As a user, I would like to be able to do X..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives considered (optional)
+      description: >
+        A clear description of alternative solutions to the problem you have considered,
+        whether that involves adding a different feature or making use of existing
+        functionality.

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,18 @@
+name: Question
+description: Ask the developers anything!
+labels: [question]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Enter your question here
+      description: >
+        Ask anything about the software and we'll get back to you shortly.
+    validations:
+      required: true
+  - type: upload
+    id: upload
+    attributes:
+      label: Upload files (optional)
+      description: >
+        Upload any additional files here.

--- a/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,32 @@
+name: Bug report
+description: File a bug report.
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: >
+        A clear and concise description of what the bug is, including error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: How to reproduce
+      description: >
+        Steps to reproduce the behaviour. Attach any relevant input file(s) below.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour (optional)
+      description: >
+        A clear and concise description of what you expected to happen.
+  - type: upload
+    id: upload
+    attributes:
+      label: Upload files (optional)
+      description: >
+        Upload any relevant files here.

--- a/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose a new feature
+labels: [enhancement]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe your proposed feature
+      description: >
+        A clear description of what the new feature should do.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Please describe the problem you are trying to address
+      description: >
+        A clear description of the problem the proposed feature addresses.
+      placeholder: >
+        E.g.: "As a user, I would like to be able to do X..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives considered (optional)
+      description: >
+        A clear description of alternative solutions to the problem you have considered,
+        whether that involves adding a different feature or making use of existing
+        functionality.

--- a/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/question.yaml
+++ b/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,18 @@
+name: Question
+description: Ask the developers anything!
+labels: [question]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Enter your question here
+      description: >
+        Ask anything about the software and we'll get back to you shortly.
+    validations:
+      required: true
+  - type: upload
+    id: upload
+    attributes:
+      label: Upload files (optional)
+      description: >
+        Upload any additional files here.


### PR DESCRIPTION
# Description

I noticed that we were missing issue templates in a repo based on this template and, when I checked, I saw that we don't actually have issue templates for this repo at all, which is a bit surprising. I wondered if we forgot to copy them when we migrated from the [old poetry template repo](https://github.com/ImperialCollegeLondon/poetry_template_2), but it seems that one doesn't have issue templates either!

Anyway, I think it's worth having issue templates. We end up adding them for most of our projects, so it makes sense to have sensible defaults. I followed @AdrianDAlessandro's suggestion in #144 of using the fancy GitHub issue forms, because they look nice and seem more user friendly than a generic text box (though you can still get this option if you select "blank issue" when creating a new issue).

I've added issue forms for bug reports and feature proposals, loosely based on the issue templates we seem to use everywhere ([example](https://github.com/EnergySystemsModellingLab/MUSE2/tree/main/.github/ISSUE_TEMPLATE)). (Who knows where they came from originally...? :thinking:) Let me know what you think!

There are forms for other kinds of issues we might want to add. For example, it might be worth having forms for documentation-related issues. I couldn't think of how this should look though and whether we should have separate forms for mistakes in documentation vs proposals for new docs vs infra-related problems etc. But if you have any good ideas, please say so and we can include them.

For now, I've used the same forms for both this repo and the template. Alas, you can't use symlinks here (I guess for security reasons), so we have two copies of these files.

You can use the `check-jsonschema` `pre-commit` hook to validate the YAML files for these forms ([see here](https://check-jsonschema.readthedocs.io/en/latest/precommit_usage.html#id18)), but unfortunately the latest version of the repo has a slightly out-of-date version of the schema, so our forms fail validation even though they're correct. We can always add this later.

Note: you can see a preview of how the forms will render by [navigating to the `ISSUE_TEMPLATE` folder on GitHub](https://github.com/ImperialCollegeLondon/python-template/tree/add-issue-forms/.github/ISSUE_TEMPLATE). I've only used some of the features of the forms, but we could add other things, like checkboxes. See [GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) for more info.

Closes #144.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
