### PR TITLE
Fix: Remove broken `taplo-lint` `pre-commit` hook

### DIFF
--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -41,5 +41,4 @@ repos:
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3
     hooks:
-      - id: taplo-format # Format TOML files
-      - id: taplo-lint
+      - id: taplo-format


### PR DESCRIPTION
# Description

It's suddenly stopped working and I don't know why. The upstream project doesn't appear to be active and neither does `taplo` itself, so I'm not especially hopeful that it'll be fixed any time soon. Let's just remove it.

Leave the `taplo-format` hook there for now, as that one appears to still work. We should perhaps think about transitioning to something else for formatting TOML though.

Upstream issue: https://github.com/ComPWA/taplo-pre-commit/issues/35
Issue about `taplo` being out of date on PyPI: https://github.com/tamasfe/taplo/issues/805

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
